### PR TITLE
Add stripHeaders configuration to ingress settings

### DIFF
--- a/charts/custom-deployment/templates/strip-headers-middleware.yaml
+++ b/charts/custom-deployment/templates/strip-headers-middleware.yaml
@@ -1,5 +1,5 @@
 {{- /* Create forwardAuth Middleware only if ingress is enabled */}}
-{{- if and .Values.ingress.enabled .Values.ingress.forwardAuth.enabled }}
+{{- if and .Values.ingress.enabled .Values.ingress.forwardAuth.enabled .Values.ingress.stripHeaders.enabled }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -10,6 +10,7 @@ metadata:
 spec:
   headers:
     customRequestHeaders:
-      Authorization: ""  # Empty value removes header
-      Cookie: ""
+      {{- range .Values.ingress.stripHeaders.headers }}
+      {{ . }}: ""  # Empty value removes header
+      {{- end }}
 {{- end }}

--- a/charts/custom-deployment/values.yaml
+++ b/charts/custom-deployment/values.yaml
@@ -87,10 +87,10 @@ ingress:
     #   - "Cookie"
     #   - "Authorization"
   stripHeaders:
-    enabled: false
+    enabled: true
     headers:
       - "Authorization"
-      - "Cookie"
+      # - "Cookie"
 
   tls: []
   #  - secretName: chart-example-tls

--- a/charts/custom-deployment/values.yaml
+++ b/charts/custom-deployment/values.yaml
@@ -86,6 +86,11 @@ ingress:
     # authRequestHeaders:
     #   - "Cookie"
     #   - "Authorization"
+  stripHeaders:
+    enabled: false
+    headers:
+      - "Authorization"
+      - "Cookie"
 
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
This PR helps with issues when stripping cookies from requests in Jupyter

## Details

This pull request introduces a new feature to dynamically strip specific headers in the `strip-headers-middleware.yaml` template based on configuration in the Helm chart values. It adds flexibility by allowing users to enable or disable the header stripping functionality and specify which headers to strip.

### Enhancements to Header Stripping Middleware:

* Updated the conditional logic in `charts/custom-deployment/templates/strip-headers-middleware.yaml` to include a check for the new `stripHeaders.enabled` flag, ensuring the middleware is only created when header stripping is enabled.
* Modified the `customRequestHeaders` section in the same file to dynamically iterate over a list of headers defined in the Helm chart values, instead of hardcoding specific headers.

### New Configuration Options in Helm Chart Values:

* Added a new `stripHeaders` section in `charts/custom-deployment/values.yaml`, which includes an `enabled` flag and a configurable list of headers to strip. This allows users to control the behavior of the middleware directly from the Helm chart values.