### PR TITLE
Extra deployment

### DIFF
--- a/charts/custom-deployment/templates/_helpers.tpl
+++ b/charts/custom-deployment/templates/_helpers.tpl
@@ -40,6 +40,9 @@ Common labels
 {{- define "custom-deployment.labels" -}}
 application: {{ .Values.labels.application }}
 helm.sh/chart: {{ include "custom-deployment.chart" . }}
+{{- if .Values.apolo_app_id }}
+apolo-app-id: {{ .Values.apolo_app_id | quote }}
+{{- end }}
 {{ include "custom-deployment.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/custom-deployment/templates/_helpers.tpl
+++ b/charts/custom-deployment/templates/_helpers.tpl
@@ -41,7 +41,7 @@ Common labels
 application: {{ .Values.labels.application }}
 helm.sh/chart: {{ include "custom-deployment.chart" . }}
 {{- if .Values.apolo_app_id }}
-apolo-app-id: {{ .Values.apolo_app_id | quote }}
+platform.apolo.us/app-id: {{ .Values.apolo_app_id | quote }}
 {{- end }}
 {{ include "custom-deployment.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/custom-deployment/templates/configmap.yaml
+++ b/charts/custom-deployment/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: {{ include "custom-deployment.fullname" . }}
+    name: {{ .Values.configMap.name | default include ("custom-deployment.fullname" .) }}
     labels:
         {{- include "custom-deployment.labels" . | nindent 4 }}
 data:

--- a/charts/custom-deployment/templates/configmap.yaml
+++ b/charts/custom-deployment/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configMap -}}
+{{- if .Values.configMap.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/custom-deployment/templates/configmap.yaml
+++ b/charts/custom-deployment/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: {{ .Values.configMap.name | default include ("custom-deployment.fullname" .) }}
+    name: {{ .Values.configMap.name | default (include "custom-deployment.fullname" .) }}
     labels:
         {{- include "custom-deployment.labels" . | nindent 4 }}
 data:

--- a/charts/custom-deployment/templates/deployment.yaml
+++ b/charts/custom-deployment/templates/deployment.yaml
@@ -11,9 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "custom-deployment.selectorLabels" . | nindent 6 }}
-    matchExpressions:
-      - key: extra-deployment-name
-        operator: DoesNotExist
+      module: main-app
   template:
     metadata:
       annotations:
@@ -21,6 +19,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       labels:
         {{- include "custom-deployment.labels" . | nindent 8 }}
+        module: main-app
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/custom-deployment/templates/deployment.yaml
+++ b/charts/custom-deployment/templates/deployment.yaml
@@ -11,6 +11,9 @@ spec:
   selector:
     matchLabels:
       {{- include "custom-deployment.selectorLabels" . | nindent 6 }}
+    matchExpressions:
+      - key: extra-deployment-name
+        operator: DoesNotExist
   template:
     metadata:
       annotations:

--- a/charts/custom-deployment/templates/deployment.yaml
+++ b/charts/custom-deployment/templates/deployment.yaml
@@ -91,10 +91,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.volumes }}
-      {{- if .Values.initContainers }}
-      initContainers:
-        {{- toYaml .Values.initContainers | nindent 8 }}
-      {{- end }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/custom-deployment/templates/deployment.yaml
+++ b/charts/custom-deployment/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.volumes }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/custom-deployment/templates/extra-deployment.yaml
+++ b/charts/custom-deployment/templates/extra-deployment.yaml
@@ -147,6 +147,7 @@ spec:
     {{- end }}
   selector:
     {{- include "custom-deployment.selectorLabels" . | nindent 4 }}
+    extra-deployment-name: {{ $name }}
 {{- end }}
 {{- if .Values.extraDeployment.configMap.enabled }}
 ---

--- a/charts/custom-deployment/templates/extra-deployment.yaml
+++ b/charts/custom-deployment/templates/extra-deployment.yaml
@@ -1,0 +1,175 @@
+{{- if .Values.extraDeployment.enabled }}
+{{ with .Values.extraDeployment }}
+{{- $name := .name |  trunc 63 | trimSuffix "-" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "custom-deployment.labels" . | nindent 4 }}
+    extra-deployment: "true"
+    {{- with .deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if not .deployment.autoscaling.enabled }}
+  replicas: {{ .deployment.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- .deployment.selectorLabels | nindent 6 }}
+      extra-deployment-name: {{ $name }}
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .deployment.podAnnotations | nindent 8 }}
+      labels:
+        extra-deployment-name: {{ $name }}
+        {{- include "custom-deployment.labels" . | nindent 8 }}
+        {{- with .deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- include "custom-deployment.apoloPodLabels" . | nindent 8 }}
+    spec:
+      {{- with .deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "custom-deployment.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .deployment.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .deployment.container.name }}
+          securityContext:
+            {{- toYaml .deployment.container.securityContext | nindent 12 }}
+          image: "{{ .deployment.container.image.repository }}:{{ .deployment.container.image.tag | default "latest" }}"
+          env:
+            {{- range .deployment.container.env }}
+              - name: {{ .name }}
+                {{- if kindIs "string" .value }}
+                value: {{ .value | quote }}
+                {{- else }}
+                {{ toYaml .value | nindent 16 }}
+                {{- end }}
+            {{- end }}
+            {{- if .APOLO_PASSED_CONFIG}}
+              - name: NEURO_PASSED_CONFIG
+                value: {{ .APOLO_PASSED_CONFIG | quote }}
+            {{- end }}
+            {{- if .deployment.includeMainDeploymentInfo }}
+              - name: MAIN_APP_DEPLOYMENT_NAME
+                value: {{ include "custom-deployment.fullname" . }}
+              - name: MAIN_APP_DEPLOYMENT_NAMESPACE
+                value: {{ .Release.Namespace }}
+              - name: MAIN_APP_RELEASE_NAME
+                value: {{ .Release.Name }}
+            {{- end }}
+          imagePullPolicy: {{ .deployment.image.pullPolicy }}
+          {{- if .deployment.container.command }}
+          command:
+            {{- toYaml .deployment.container.command | nindent 12 }}
+          {{- end }}
+          {{- if .deployment.container.entrypoint }}
+          entrypoint:
+            {{- toYaml .deployment.container.entrypoint | nindent 12 }}
+          {{- end }}
+          {{- if .deployment.container.args }}
+          args:
+            {{- toYaml .deployment.container.args | nindent 12 }}
+          {{- end }}
+          ports:
+            {{- range .service.ports }}
+            - containerPort: {{ .containerPort }}
+              protocol: TCP
+              name: {{ .name }}
+            {{- end }}
+          {{- if .health_checks }}
+          {{- if .health_checks.livenessProbe }}
+          livenessProbe:
+            {{- .health_checks.livenessProbe | toYaml | nindent 12 }}
+            successThreshold: 1
+          {{- end }}
+          {{- if .health_checks.startupProbe }}
+          startupProbe:
+            {{- .health_checks.startupProbe | toYaml | nindent 12 }}
+            successThreshold: 1
+          {{- end }}
+          {{- if .health_checks.readinessProbe }}
+          readinessProbe:
+            {{- .health_checks.readinessProbe | toYaml | nindent 12 }}
+            successThreshold: 1
+          {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
+          {{- with .volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .volumes }}
+      {{- if .initContainers }}
+      initContainers:
+        {{- toYaml .initContainers | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .dockerconfigjson }}
+      imagePullSecrets:
+        - name: {{ include "custom-deployment.dockerconfig-secret-name" . }}
+      {{- end }}
+{{- if .service.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "custom-deployment.labels" . | nindent 4 }}
+    extra-deployment: "true"
+    {{- with .service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .service.type }}
+  ports:
+    {{- range .service.ports }}
+    - port: {{ .containerPort }}
+      targetPort: {{ .name }}
+      protocol: TCP
+      name: {{ .name }}
+    {{- end }}
+  selector:
+    {{- include "custom-deployment.selectorLabels" . | nindent 4 }}
+{{- end }}
+{{- if .configMap.enabled -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .confiMap.name | default $name }}
+   labels:
+    {{- include "custom-deployment.labels" . | nindent 4 }}
+    extra-deployment: "true"
+    {{- with .deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+{{- range $key, $value := .configMap.data }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/custom-deployment/templates/extra-deployment.yaml
+++ b/charts/custom-deployment/templates/extra-deployment.yaml
@@ -8,43 +8,43 @@ metadata:
   labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
     extra-deployment: "true"
-    {{- with .deployment.labels }}
+    {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not .deployment.autoscaling.enabled }}
-  replicas: {{ .deployment.replicaCount }}
+  {{- if not .autoscaling.enabled }}
+  replicas: {{ .replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- .deployment.selectorLabels | nindent 6 }}
+      {{- include "custom-deployment.selectorLabels" . | nindent 6 }}
       extra-deployment-name: {{ $name }}
   template:
     metadata:
       annotations:
-        {{- toYaml .deployment.podAnnotations | nindent 8 }}
+        {{- toYaml .podAnnotations | nindent 8 }}
       labels:
         extra-deployment-name: {{ $name }}
         {{- include "custom-deployment.labels" . | nindent 8 }}
-        {{- with .deployment.podLabels }}
+        {{- with .podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "custom-deployment.apoloPodLabels" . | nindent 8 }}
     spec:
-      {{- with .deployment.imagePullSecrets }}
+      {{- with .imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "custom-deployment.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .deployment.podSecurityContext | nindent 8 }}
+        {{- toYaml .podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .deployment.container.name }}
+        - name: {{ .name }}
           securityContext:
-            {{- toYaml .deployment.container.securityContext | nindent 12 }}
-          image: "{{ .deployment.container.image.repository }}:{{ .deployment.container.image.tag | default "latest" }}"
+            {{- toYaml .securityContext | nindent 12 }}
+          image: "{{ .image.repository }}:{{ .image.tag | default "latest" }}"
           env:
-            {{- range .deployment.container.env }}
+            {{- range .container.env }}
               - name: {{ .name }}
                 {{- if kindIs "string" .value }}
                 value: {{ .value | quote }}
@@ -56,7 +56,7 @@ spec:
               - name: NEURO_PASSED_CONFIG
                 value: {{ .APOLO_PASSED_CONFIG | quote }}
             {{- end }}
-            {{- if .deployment.includeMainDeploymentInfo }}
+            {{- if .includeMainDeploymentInfo }}
               - name: MAIN_APP_DEPLOYMENT_NAME
                 value: {{ include "custom-deployment.fullname" . }}
               - name: MAIN_APP_DEPLOYMENT_NAMESPACE
@@ -64,18 +64,18 @@ spec:
               - name: MAIN_APP_RELEASE_NAME
                 value: {{ .Release.Name }}
             {{- end }}
-          imagePullPolicy: {{ .deployment.image.pullPolicy }}
-          {{- if .deployment.container.command }}
+          imagePullPolicy: {{ .image.pullPolicy }}
+          {{- if .container.command }}
           command:
-            {{- toYaml .deployment.container.command | nindent 12 }}
+            {{- toYaml .container.command | nindent 12 }}
           {{- end }}
-          {{- if .deployment.container.entrypoint }}
+          {{- if .container.entrypoint }}
           entrypoint:
-            {{- toYaml .deployment.container.entrypoint | nindent 12 }}
+            {{- toYaml .container.entrypoint | nindent 12 }}
           {{- end }}
-          {{- if .deployment.container.args }}
+          {{- if .container.args }}
           args:
-            {{- toYaml .deployment.container.args | nindent 12 }}
+            {{- toYaml .container.args | nindent 12 }}
           {{- end }}
           ports:
             {{- range .service.ports }}
@@ -163,7 +163,7 @@ metadata:
    labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
     extra-deployment: "true"
-    {{- with .deployment.labels }}
+    {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 data:

--- a/charts/custom-deployment/templates/extra-deployment.yaml
+++ b/charts/custom-deployment/templates/extra-deployment.yaml
@@ -100,7 +100,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.extraDeployment.resources | nindent 12 }}
-          {{- with .volumeMounts }}
+          {{- with .Values.extraDeployment.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/custom-deployment/templates/extra-deployment.yaml
+++ b/charts/custom-deployment/templates/extra-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
-    extra-deployment: "true"
+    module: extra-deployment
     {{- with .Values.extraDeployment.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -17,13 +17,13 @@ spec:
   selector:
     matchLabels:
       {{- include "custom-deployment.selectorLabels" . | nindent 6 }}
-      extra-deployment-name: {{ $name }}
+      module: extra-deployment
   template:
     metadata:
       annotations:
         {{- toYaml .Values.extraDeployment.podAnnotations | nindent 8 }}
       labels:
-        extra-deployment-name: {{ $name }}
+        module: extra-deployment
         {{- include "custom-deployment.labels" . | nindent 8 }}
         {{- with .Values.extraDeployment.podLabels }}
         {{- toYaml . | nindent 8 }}
@@ -132,7 +132,7 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
-    extra-deployment: "true"
+    module: extra-deployment
     {{- with .Values.extraDeployment.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -147,7 +147,7 @@ spec:
     {{- end }}
   selector:
     {{- include "custom-deployment.selectorLabels" . | nindent 4 }}
-    extra-deployment-name: {{ $name }}
+    module: extra-deployment
 {{- end }}
 {{- if .Values.extraDeployment.configMap.enabled }}
 ---
@@ -157,7 +157,7 @@ metadata:
   name: {{ .Values.extraDeployment.configMap.name | default $name }}
   labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
-    extra-deployment: "true"
+    module: extra-deployment
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/custom-deployment/templates/extra-deployment.yaml
+++ b/charts/custom-deployment/templates/extra-deployment.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.extraDeployment.enabled }}
-{{ with .Values.extraDeployment }}
-{{- $name := .name |  trunc 63 | trimSuffix "-" }}
+{{- $name := .Values.extraDeployment.name |  trunc 63 | trimSuffix "-" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,12 +7,12 @@ metadata:
   labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
     extra-deployment: "true"
-    {{- with .labels }}
+    {{- with .Values.extraDeployment.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not .autoscaling.enabled }}
-  replicas: {{ .replicaCount }}
+  {{- if not .Values.extraDeployment.autoscaling.enabled }}
+  replicas: {{ .Values.extraDeployment.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -22,29 +21,28 @@ spec:
   template:
     metadata:
       annotations:
-        {{- toYaml .podAnnotations | nindent 8 }}
+        {{- toYaml .Values.extraDeployment.podAnnotations | nindent 8 }}
       labels:
         extra-deployment-name: {{ $name }}
         {{- include "custom-deployment.labels" . | nindent 8 }}
-        {{- with .podLabels }}
+        {{- with .Values.extraDeployment.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- include "custom-deployment.apoloPodLabels" . | nindent 8 }}
     spec:
-      {{- with .imagePullSecrets }}
+      {{- with .Values.extraDeployment.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "custom-deployment.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.extraDeployment.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .name }}
+        - name: {{ $name }}
           securityContext:
-            {{- toYaml .securityContext | nindent 12 }}
-          image: "{{ .image.repository }}:{{ .image.tag | default "latest" }}"
+            {{- toYaml .Values.extraDeployment.securityContext | nindent 12 }}
+          image: "{{ .Values.extraDeployment.image.repository }}:{{ .Values.extraDeployment.image.tag | default "latest" }}"
           env:
-            {{- range .container.env }}
+            {{- range .Values.extraDeployment.container.env }}
               - name: {{ .name }}
                 {{- if kindIs "string" .value }}
                 value: {{ .value | quote }}
@@ -52,11 +50,11 @@ spec:
                 {{ toYaml .value | nindent 16 }}
                 {{- end }}
             {{- end }}
-            {{- if .APOLO_PASSED_CONFIG}}
+            {{- if .Values.extraDeployment.APOLO_PASSED_CONFIG}}
               - name: NEURO_PASSED_CONFIG
-                value: {{ .APOLO_PASSED_CONFIG | quote }}
+                value: {{ .Values.extraDeployment.APOLO_PASSED_CONFIG | quote }}
             {{- end }}
-            {{- if .includeMainDeploymentInfo }}
+            {{- if .Values.extraDeployment.includeMainDeploymentInfo }}
               - name: MAIN_APP_DEPLOYMENT_NAME
                 value: {{ include "custom-deployment.fullname" . }}
               - name: MAIN_APP_DEPLOYMENT_NAMESPACE
@@ -64,73 +62,69 @@ spec:
               - name: MAIN_APP_RELEASE_NAME
                 value: {{ .Release.Name }}
             {{- end }}
-          imagePullPolicy: {{ .image.pullPolicy }}
-          {{- if .container.command }}
+          imagePullPolicy: {{ .Values.extraDeployment.image.pullPolicy }}
+          {{- if .Values.extraDeployment.container.command }}
           command:
-            {{- toYaml .container.command | nindent 12 }}
+            {{- toYaml .Values.extraDeployment.container.command | nindent 12 }}
           {{- end }}
-          {{- if .container.entrypoint }}
+          {{- if .Values.extraDeployment.container.entrypoint }}
           entrypoint:
-            {{- toYaml .container.entrypoint | nindent 12 }}
+            {{- toYaml .Values.extraDeployment.container.entrypoint | nindent 12 }}
           {{- end }}
-          {{- if .container.args }}
+          {{- if .Values.extraDeployment.container.args }}
           args:
-            {{- toYaml .container.args | nindent 12 }}
+            {{- toYaml .Values.extraDeployment.container.args | nindent 12 }}
           {{- end }}
           ports:
-            {{- range .service.ports }}
+            {{- range .Values.extraDeployment.service.ports }}
             - containerPort: {{ .containerPort }}
               protocol: TCP
               name: {{ .name }}
             {{- end }}
-          {{- if .health_checks }}
-          {{- if .health_checks.livenessProbe }}
+          {{- if .Values.extraDeployment.health_checks }}
+          {{- if .Values.extraDeployment.health_checks.livenessProbe }}
           livenessProbe:
-            {{- .health_checks.livenessProbe | toYaml | nindent 12 }}
+            {{- .Values.extraDeployment.health_checks.livenessProbe | toYaml | nindent 12 }}
             successThreshold: 1
           {{- end }}
-          {{- if .health_checks.startupProbe }}
+          {{- if .Values.extraDeployment.health_checks.startupProbe }}
           startupProbe:
-            {{- .health_checks.startupProbe | toYaml | nindent 12 }}
+            {{- .Values.extraDeployment.health_checks.startupProbe | toYaml | nindent 12 }}
             successThreshold: 1
           {{- end }}
-          {{- if .health_checks.readinessProbe }}
+          {{- if .Values.extraDeployment.health_checks.readinessProbe }}
           readinessProbe:
-            {{- .health_checks.readinessProbe | toYaml | nindent 12 }}
+            {{- .Values.extraDeployment.health_checks.readinessProbe | toYaml | nindent 12 }}
             successThreshold: 1
           {{- end }}
           {{- end }}
           resources:
-            {{- toYaml .resources | nindent 12 }}
+            {{- toYaml .Values.extraDeployment.resources | nindent 12 }}
           {{- with .volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .volumes }}
-      {{- if .initContainers }}
-      initContainers:
-        {{- toYaml .initContainers | nindent 8 }}
-      {{- end }}
+      {{- with .Values.extraDeployment.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .nodeSelector }}
+      {{- with .Values.extraDeployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .affinity }}
+      {{- with .Values.extraDeployment.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .tolerations }}
+      {{- with .Values.extraDeployment.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .dockerconfigjson }}
+      {{- if .Values.extraDeployment.dockerconfigjson }}
       imagePullSecrets:
         - name: {{ include "custom-deployment.dockerconfig-secret-name" . }}
       {{- end }}
-{{- if .service.enabled }}
+{{- if .Values.extraDeployment.service.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -139,13 +133,13 @@ metadata:
   labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
     extra-deployment: "true"
-    {{- with .service.labels }}
+    {{- with .Values.extraDeployment.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ .service.type }}
+  type: {{ .Values.extraDeployment.service.type }}
   ports:
-    {{- range .service.ports }}
+    {{- range .Values.extraDeployment.service.ports }}
     - port: {{ .containerPort }}
       targetPort: {{ .name }}
       protocol: TCP
@@ -154,22 +148,21 @@ spec:
   selector:
     {{- include "custom-deployment.selectorLabels" . | nindent 4 }}
 {{- end }}
-{{- if .configMap.enabled -}}
+{{- if .Values.extraDeployment.configMap.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .confiMap.name | default $name }}
-   labels:
+  name: {{ .Values.extraDeployment.configMap.name | default $name }}
+  labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
     extra-deployment: "true"
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 data:
-{{- range $key, $value := .configMap.data }}
+{{- range $key, $value := .Values.extraDeployment.configMap.data }}
   {{ $key }}: {{ $value | quote }}
 {{- end }}
-{{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/custom-deployment/templates/service.yaml
+++ b/charts/custom-deployment/templates/service.yaml
@@ -15,9 +15,6 @@ spec:
       name: {{ .name }}
     {{- end }}
   selector:
-    matchLabels:
-      {{- include "custom-deployment.selectorLabels" . | nindent 6 }}
-    matchExpressions:
-      - key: extra-deployment-name
-        operator: DoesNotExist
+    {{- include "custom-deployment.selectorLabels" . | nindent 6 }}
+    module: main-app
 {{- end }}

--- a/charts/custom-deployment/templates/service.yaml
+++ b/charts/custom-deployment/templates/service.yaml
@@ -15,6 +15,6 @@ spec:
       name: {{ .name }}
     {{- end }}
   selector:
-    {{- include "custom-deployment.selectorLabels" . | nindent 6 }}
+    {{- include "custom-deployment.selectorLabels" . | nindent 4 }}
     module: main-app
 {{- end }}

--- a/charts/custom-deployment/templates/service.yaml
+++ b/charts/custom-deployment/templates/service.yaml
@@ -15,5 +15,9 @@ spec:
       name: {{ .name }}
     {{- end }}
   selector:
-    {{- include "custom-deployment.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "custom-deployment.selectorLabels" . | nindent 6 }}
+    matchExpressions:
+      - key: extra-deployment-name
+        operator: DoesNotExist
 {{- end }}

--- a/charts/custom-deployment/templates/service.yaml
+++ b/charts/custom-deployment/templates/service.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "custom-deployment.fullname" . }}
   labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
-    {{ .Values.service.labels | nindent 4 }}
+    {{- if .Values.service.labels }}
+    {{ toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/custom-deployment/templates/service.yaml
+++ b/charts/custom-deployment/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "custom-deployment.fullname" . }}
   labels:
     {{- include "custom-deployment.labels" . | nindent 4 }}
+    {{ .Values.service.labels | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/custom-deployment/values.yaml
+++ b/charts/custom-deployment/values.yaml
@@ -171,3 +171,113 @@ labels:
   application: custom-deployment
 
 APOLO_PASSED_CONFIG: null
+
+extraDeployment:
+  enabled: false
+  deployment:
+    # This is the name of the deployment
+    name: "extra-deployment"
+    # Replica count for the extra deployment
+    replicaCount: 1
+    # Autoscaling configuration
+    autoscaling:
+      enabled: false
+    # Selector labels for the deployment
+    selectorLabels: {}
+    # Pod annotations
+    podAnnotations: {}
+    # Pod labels
+    podLabels: {}
+    # Additional deployment labels
+    labels: {}
+    # Image pull secrets
+    imagePullSecrets: []
+    # Pod security context
+    podSecurityContext: {}
+    # Include main deployment info as environment variables
+    includeMainDeploymentInfo: true
+    # This is the container command for the deployment
+    container:
+      entrypoint: null
+      command: []
+      args: []
+      name: extra-deployment-container
+      securityContext: {}
+      image:
+        repository: "nginx"
+        tag: "latest"
+        pullPolicy: IfNotPresent
+      env:
+        - name: APOLO_PASSED_CONFIG
+          value: ""
+  # Service configuration for extra deployment
+  service:
+    enabled: true
+    type: ClusterIP
+    ports:
+      - name: http
+        containerPort: 80
+    labels: {}
+  # Health checks configuration
+  health_checks:
+    livenessProbe: null
+    # Example:
+    # livenessProbe:
+    #   httpGet:
+    #     path: /health
+    #     port: 80
+    #   initialDelaySeconds: 30
+    #   periodSeconds: 10
+    startupProbe: null
+    # Example:
+    # startupProbe:
+    #   httpGet:
+    #     path: /health
+    #     port: 80
+    #   initialDelaySeconds: 10
+    #   periodSeconds: 5
+    readinessProbe: null
+    # Example:
+    # readinessProbe:
+    #   httpGet:
+    #     path: /ready
+    #     port: 80
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 5
+  # Resource limits and requests
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  # Volume mounts
+  volumeMounts: []
+  # - name: config-volume
+  #   mountPath: /etc/config
+  #   readOnly: true
+  # Volumes
+  volumes: []
+  # - name: config-volume
+  #   configMap:
+  #     name: my-config
+  # Init containers
+  initContainers: []
+  # - name: init-container
+  #   image: busybox
+  #   command: ['sh', '-c', 'echo init']
+  # Node selector
+  nodeSelector: {}
+  # Affinity rules
+  affinity: {}
+  # Tolerations
+  tolerations: []
+  # Docker config for private registries
+  dockerconfigjson: null
+configMap:
+  enabled: false
+  name: "extra-deployment-configmap"
+  data: {}
+    # key1: value1
+    # key2: value2

--- a/charts/custom-deployment/values.yaml
+++ b/charts/custom-deployment/values.yaml
@@ -265,6 +265,12 @@ extraDeployment:
   tolerations: []
   # Docker config for private registries
   dockerconfigjson: null
+  configMap:
+    enabled: false
+    name: "extra-deployment-configmap"
+    data: {}
+      # key1: value1
+      # key2: value2
 configMap:
   enabled: false
   name: "extra-deployment-configmap"

--- a/charts/custom-deployment/values.yaml
+++ b/charts/custom-deployment/values.yaml
@@ -174,42 +174,32 @@ APOLO_PASSED_CONFIG: null
 
 extraDeployment:
   enabled: false
-  deployment:
-    # This is the name of the deployment
-    name: "extra-deployment"
-    # Replica count for the extra deployment
-    replicaCount: 1
-    # Autoscaling configuration
-    autoscaling:
-      enabled: false
-    # Selector labels for the deployment
-    selectorLabels: {}
-    # Pod annotations
-    podAnnotations: {}
-    # Pod labels
-    podLabels: {}
-    # Additional deployment labels
-    labels: {}
-    # Image pull secrets
-    imagePullSecrets: []
-    # Pod security context
-    podSecurityContext: {}
-    # Include main deployment info as environment variables
-    includeMainDeploymentInfo: true
-    # This is the container command for the deployment
-    container:
-      entrypoint: null
-      command: []
-      args: []
-      name: extra-deployment-container
-      securityContext: {}
-      image:
-        repository: "nginx"
-        tag: "latest"
-        pullPolicy: IfNotPresent
-      env:
-        - name: APOLO_PASSED_CONFIG
-          value: ""
+  name: "extra-deployment"
+  image:
+    repository: "nginx"
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  # Image pull secrets
+  imagePullSecrets: []
+  container:
+    entrypoint: null
+    command: []
+    args: []
+    env:
+      - name: APOLO_PASSED_CONFIG
+        value: ""
+  securityContext: {}
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+  podAnnotations: {}
+  podLabels: {}
+  labels: {}
+  # Pod security context
+  podSecurityContext: {}
+  # Include main deployment info as environment variables
+  includeMainDeploymentInfo: true
+  # This is the container command for the deployment
   # Service configuration for extra deployment
   service:
     enabled: true

--- a/charts/custom-deployment/values.yaml
+++ b/charts/custom-deployment/values.yaml
@@ -64,6 +64,7 @@ service:
   ports:
     - name: http
       containerPort: 80
+  labels: {}
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
@@ -169,6 +170,8 @@ persistentVolumeClaims: []
 
 labels:
   application: custom-deployment
+
+# apolo_app_id: <app-uid>
 
 APOLO_PASSED_CONFIG: null
 


### PR DESCRIPTION
Enabled an "extra deployment" inside Custom Deployment. 

This can be used to deploy a Dynamic Output server.

I added some extra labels so we can identify the "main-app" services and the "extra-app" ones.

Also added support for `apolo-app-id` labels in deployments.

