### PR TITLE
IT-56: rename dockerconfigjson to imagepullsecret, support GitHub registry auth

### DIFF
--- a/.apolo/src/apolo_apps_fooocus/schemas/FooocusAppOutputs.json
+++ b/.apolo/src/apolo_apps_fooocus/schemas/FooocusAppOutputs.json
@@ -42,7 +42,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Service APIs",
-      "x-type": "ServiceAPI[GrpcAPI]"
+      "x-type": "ServiceAPI[WebApp]"
     },
     "WebApp": {
       "properties": {
@@ -115,7 +115,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "WebApp"
     }
   },
   "properties": {

--- a/.apolo/src/apolo_apps_jupyter/schemas/JupyterAppInputs.json
+++ b/.apolo/src/apolo_apps_jupyter/schemas/JupyterAppInputs.json
@@ -70,7 +70,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Apolo Files Path",
-      "x-type": "ApoloFilesFile"
+      "x-type": "ApoloFilesPath"
     },
     "ApoloMountMode": {
       "properties": {
@@ -255,21 +255,25 @@
           "x-meta-type": "inline",
           "x-title": "Container Image Tag"
         },
-        "dockerconfigjson": {
+        "imagepullsecret": {
           "anyOf": [
             {
               "$ref": "#/$defs/DockerConfigModel"
+            },
+            {
+              "$ref": "#/$defs/GithubImageRegistryAuth"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "x-description": "ImagePullSecrets for DockerHub",
+          "title": "Imagepullsecret",
+          "x-description": "Credentials used to pull the container image from a private registry: either a Docker config (e.g. from the DockerHub app) or a GitHub Container Registry auth (from the GitHub app).",
           "x-is-advanced-field": false,
           "x-is-configurable": true,
           "x-meta-type": "integration",
-          "x-title": "ImagePullSecrets for DockerHub"
+          "x-title": "Image Pull Secret"
         },
         "pull_policy": {
           "$ref": "#/$defs/ContainerImagePullPolicy",
@@ -441,6 +445,46 @@
       "x-meta-type": "inline",
       "x-title": "Env",
       "x-type": "Env"
+    },
+    "GithubImageRegistryAuth": {
+      "properties": {
+        "username": {
+          "title": "Username",
+          "type": "string",
+          "x-description": "GitHub account username the personal access token belongs to.",
+          "x-is-advanced-field": false,
+          "x-is-configurable": true,
+          "x-meta-type": "inline",
+          "x-title": "Username"
+        },
+        "token": {
+          "$ref": "#/$defs/ApoloSecret",
+          "x-description": "GitHub personal access token (classic). For pulling container images it needs the read:packages scope, see https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries",
+          "x-title": "GitHub Personal Access Token"
+        },
+        "registry_url": {
+          "default": "ghcr.io",
+          "title": "Registry Url",
+          "type": "string",
+          "x-description": "Container registry host. Use ghcr.io for github.com or containers.HOSTNAME for GitHub Enterprise Server.",
+          "x-is-advanced-field": false,
+          "x-is-configurable": true,
+          "x-meta-type": "inline",
+          "x-title": "Registry Host"
+        }
+      },
+      "required": [
+        "username",
+        "token"
+      ],
+      "title": "GithubImageRegistryAuth",
+      "type": "object",
+      "x-description": "Credentials for pulling container images from the GitHub Container Registry (ghcr.io or a GitHub Enterprise Server host).",
+      "x-is-advanced-field": false,
+      "x-is-configurable": true,
+      "x-meta-type": "integration",
+      "x-title": "GitHub Container Registry Auth",
+      "x-type": "GithubImageRegistryAuth"
     },
     "IngressHttp": {
       "properties": {
@@ -710,7 +754,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "RestAPI"
     },
     "StorageMounts": {
       "properties": {

--- a/.apolo/src/apolo_apps_jupyter/schemas/JupyterAppOutputs.json
+++ b/.apolo/src/apolo_apps_jupyter/schemas/JupyterAppOutputs.json
@@ -42,7 +42,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Service APIs",
-      "x-type": "ServiceAPI[GrpcAPI]"
+      "x-type": "ServiceAPI[WebApp]"
     },
     "WebApp": {
       "properties": {
@@ -115,7 +115,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "WebApp"
     }
   },
   "properties": {

--- a/.apolo/src/apolo_apps_mlflow_core/schemas/MLFlowAppInputs.json
+++ b/.apolo/src/apolo_apps_mlflow_core/schemas/MLFlowAppInputs.json
@@ -41,7 +41,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Apolo Files Path",
-      "x-type": "ApoloFilesFile"
+      "x-type": "ApoloFilesPath"
     },
     "ApoloSecret": {
       "properties": {

--- a/.apolo/src/apolo_apps_mlflow_core/schemas/MLFlowAppOutputs.json
+++ b/.apolo/src/apolo_apps_mlflow_core/schemas/MLFlowAppOutputs.json
@@ -553,7 +553,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "RestAPI"
     },
     "ServiceAPI_WebApp_": {
       "properties": {
@@ -597,7 +597,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Service APIs",
-      "x-type": "ServiceAPI[GrpcAPI]"
+      "x-type": "ServiceAPI[WebApp]"
     },
     "WebApp": {
       "properties": {
@@ -670,7 +670,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "WebApp"
     }
   },
   "properties": {

--- a/.apolo/src/apolo_apps_openwebui/schemas/OpenWebUIAppInputs.json
+++ b/.apolo/src/apolo_apps_openwebui/schemas/OpenWebUIAppInputs.json
@@ -41,7 +41,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Apolo Files Path",
-      "x-type": "ApoloFilesFile"
+      "x-type": "ApoloFilesPath"
     },
     "ApoloSecret": {
       "properties": {

--- a/.apolo/src/apolo_apps_openwebui/schemas/OpenWebUIAppOutputs.json
+++ b/.apolo/src/apolo_apps_openwebui/schemas/OpenWebUIAppOutputs.json
@@ -42,7 +42,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Service APIs",
-      "x-type": "ServiceAPI[GrpcAPI]"
+      "x-type": "ServiceAPI[WebApp]"
     },
     "WebApp": {
       "properties": {
@@ -115,7 +115,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "WebApp"
     }
   },
   "properties": {

--- a/.apolo/src/apolo_apps_privategpt/schemas/PrivateGPTAppInputs.json
+++ b/.apolo/src/apolo_apps_privategpt/schemas/PrivateGPTAppInputs.json
@@ -41,7 +41,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Apolo Files Path",
-      "x-type": "ApoloFilesFile"
+      "x-type": "ApoloFilesPath"
     },
     "ApoloSecret": {
       "properties": {

--- a/.apolo/src/apolo_apps_privategpt/schemas/PrivateGPTAppOutputs.json
+++ b/.apolo/src/apolo_apps_privategpt/schemas/PrivateGPTAppOutputs.json
@@ -42,7 +42,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Service APIs",
-      "x-type": "ServiceAPI[GrpcAPI]"
+      "x-type": "ServiceAPI[WebApp]"
     },
     "WebApp": {
       "properties": {
@@ -115,7 +115,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "WebApp"
     }
   },
   "description": "PrivateGPT outputs:\n  - app_url (inherited from AppOutputs)",

--- a/.apolo/src/apolo_apps_service_deployment/schemas/ServiceDeploymentInputs.json
+++ b/.apolo/src/apolo_apps_service_deployment/schemas/ServiceDeploymentInputs.json
@@ -70,7 +70,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Apolo Files Path",
-      "x-type": "ApoloFilesFile"
+      "x-type": "ApoloFilesPath"
     },
     "ApoloMountMode": {
       "properties": {
@@ -362,21 +362,25 @@
           "x-meta-type": "inline",
           "x-title": "Container Image Tag"
         },
-        "dockerconfigjson": {
+        "imagepullsecret": {
           "anyOf": [
             {
               "$ref": "#/$defs/DockerConfigModel"
+            },
+            {
+              "$ref": "#/$defs/GithubImageRegistryAuth"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "x-description": "ImagePullSecrets for DockerHub",
+          "title": "Imagepullsecret",
+          "x-description": "Credentials used to pull the container image from a private registry: either a Docker config (e.g. from the DockerHub app) or a GitHub Container Registry auth (from the GitHub app).",
           "x-is-advanced-field": false,
           "x-is-configurable": true,
           "x-meta-type": "integration",
-          "x-title": "ImagePullSecrets for DockerHub"
+          "x-title": "Image Pull Secret"
         },
         "pull_policy": {
           "$ref": "#/$defs/ContainerImagePullPolicy",
@@ -581,6 +585,46 @@
       "x-meta-type": "inline",
       "x-title": "gRPC Health Check",
       "x-type": "GRPCHealthCheckConfig"
+    },
+    "GithubImageRegistryAuth": {
+      "properties": {
+        "username": {
+          "title": "Username",
+          "type": "string",
+          "x-description": "GitHub account username the personal access token belongs to.",
+          "x-is-advanced-field": false,
+          "x-is-configurable": true,
+          "x-meta-type": "inline",
+          "x-title": "Username"
+        },
+        "token": {
+          "$ref": "#/$defs/ApoloSecret",
+          "x-description": "GitHub personal access token (classic). For pulling container images it needs the read:packages scope, see https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries",
+          "x-title": "GitHub Personal Access Token"
+        },
+        "registry_url": {
+          "default": "ghcr.io",
+          "title": "Registry Url",
+          "type": "string",
+          "x-description": "Container registry host. Use ghcr.io for github.com or containers.HOSTNAME for GitHub Enterprise Server.",
+          "x-is-advanced-field": false,
+          "x-is-configurable": true,
+          "x-meta-type": "inline",
+          "x-title": "Registry Host"
+        }
+      },
+      "required": [
+        "username",
+        "token"
+      ],
+      "title": "GithubImageRegistryAuth",
+      "type": "object",
+      "x-description": "Credentials for pulling container images from the GitHub Container Registry (ghcr.io or a GitHub Enterprise Server host).",
+      "x-is-advanced-field": false,
+      "x-is-configurable": true,
+      "x-meta-type": "integration",
+      "x-title": "GitHub Container Registry Auth",
+      "x-type": "GithubImageRegistryAuth"
     },
     "HTTPHealthCheckConfig": {
       "description": "HTTP-specific health check configuration.",
@@ -1050,7 +1094,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "",
-      "x-type": "Image"
+      "x-type": "Port"
     },
     "Preset": {
       "properties": {

--- a/.apolo/src/apolo_apps_service_deployment/schemas/ServiceDeploymentOutputs.json
+++ b/.apolo/src/apolo_apps_service_deployment/schemas/ServiceDeploymentOutputs.json
@@ -42,7 +42,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Service APIs",
-      "x-type": "ServiceAPI[GrpcAPI]"
+      "x-type": "ServiceAPI[WebApp]"
     },
     "WebApp": {
       "properties": {
@@ -115,7 +115,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "WebApp"
     }
   },
   "properties": {

--- a/.apolo/src/apolo_apps_shell/schemas/ShellAppOutputs.json
+++ b/.apolo/src/apolo_apps_shell/schemas/ShellAppOutputs.json
@@ -42,7 +42,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Service APIs",
-      "x-type": "ServiceAPI[GrpcAPI]"
+      "x-type": "ServiceAPI[WebApp]"
     },
     "WebApp": {
       "properties": {
@@ -115,7 +115,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "WebApp"
     }
   },
   "properties": {

--- a/.apolo/src/apolo_apps_vscode/schemas/VSCodeAppInputs.json
+++ b/.apolo/src/apolo_apps_vscode/schemas/VSCodeAppInputs.json
@@ -70,7 +70,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Apolo Files Path",
-      "x-type": "ApoloFilesFile"
+      "x-type": "ApoloFilesPath"
     },
     "ApoloMountMode": {
       "properties": {
@@ -384,7 +384,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "RestAPI"
     },
     "StorageMounts": {
       "properties": {

--- a/.apolo/src/apolo_apps_vscode/schemas/VSCodeAppOutputs.json
+++ b/.apolo/src/apolo_apps_vscode/schemas/VSCodeAppOutputs.json
@@ -42,7 +42,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "Service APIs",
-      "x-type": "ServiceAPI[GrpcAPI]"
+      "x-type": "ServiceAPI[WebApp]"
     },
     "WebApp": {
       "properties": {
@@ -115,7 +115,7 @@
       "x-is-configurable": true,
       "x-meta-type": "inline",
       "x-title": "HTTP API",
-      "x-type": "OpenAICompatibleEmbeddingsRestAPI"
+      "x-type": "WebApp"
     }
   },
   "properties": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -299,14 +299,14 @@ trio = ["trio (>=0.32.0)"]
 
 [[package]]
 name = "apolo-app-types"
-version = "26.7.1"
+version = "26.8.0"
 description = "Apolo Platform App Types."
 optional = false
 python-versions = "<4.0,>=3.10.0"
 groups = ["main"]
 files = [
-    {file = "apolo_app_types-26.7.1-py3-none-any.whl", hash = "sha256:9f41428967d3504326f1e5f2c59c60a6b167ddb9a0a25488deb16779a7374cf3"},
-    {file = "apolo_app_types-26.7.1.tar.gz", hash = "sha256:2100f0aa5f68e082f37dcc54fb7b3a757f5be4ee9a77841d953e93c8dcf1118c"},
+    {file = "apolo_app_types-26.8.0-py3-none-any.whl", hash = "sha256:765e7e80b43b62a5c9c7f051bb643c85470898a770b27ae8ba813cd5771f6a2d"},
+    {file = "apolo_app_types-26.8.0.tar.gz", hash = "sha256:99efd79d0442ac9dc7d787116e957f1350d267ac136c0bdf4af50ffc7bcbd7d2"},
 ]
 
 [package.dependencies]
@@ -3113,4 +3113,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0,<4.0"
-content-hash = "16a10e537471c14ac7980d8c4ddfcbdabe86d18dfc60347146020e5977f72149"
+content-hash = "f94123b388c9ecd6257f4b33cb3684eb6e77c18ddd82505ab3227be9810f9689"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ pydantic = "^2.13.4"
 pyyaml = "^6.0.2"
 types-PyYAML = "^6.0.12.20260724"
 yarl = "^1.24.5"
-apolo-app-types = "^26.7.1"
+apolo-app-types = "^26.8.0"
 pre-commit = "^4.6.1"
 multidict = "^6.7.1"
 


### PR DESCRIPTION
## What

Per review, this PR is now limited to consuming the app-types change ([IT-56](https://apolocloud.atlassian.net/browse/IT-56)): all gh-registry support lives in app-types (neuro-inc/app-types#486), where `ContainerImage` gained the `imagepullsecret` union (`DockerConfigModel | GithubImageRegistryAuth`) and the base `CustomDeploymentChartValueProcessor` resolves it — so service-deployment and every other app in this repo get it with no app-specific code.

- bump `apolo-app-types` (temporary git dependency on the feature branch)
- regenerate all app schemas: they pick up `imagepullsecret` on `ContainerImage` and corrected `x-type` values (previously polluted by the upstream `__init_subclass__` in-place mutation, fixed in #486)
- `git` added to `hooks.Dockerfile` (needed only while the dependency is a git ref — poetry-dynamic-versioning shells out to git)

## Before merge

- [x] neuro-inc/app-types#486 merged (+ follow-up #491); released as v26.8.0
- [x] swapped to `^26.8.0`, re-locked, `git` dropped from `hooks.Dockerfile`
- [ ] in-cluster deployment test with the GitHub app integration
- [ ] service-deployment <> GitHub app docs

## Verification

- Local e2e re-run against the reworked upstream processor (`CustomDeploymentChartValueProcessor` from #486, live apolo client, real Apolo secret): rendered credentials pulled a genuinely private ghcr.io image (anonymous 401, rendered auth 200).
- Precedence and rendering unit tests live in app-types (`tests/unit/custom_deployment/test_custom_deployment_imagepullsecret.py`).


[IT-56]: https://apolocloud.atlassian.net/browse/IT-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



