### PR TITLE
IT-122: bump MLflow server image to v3.15.1

### DIFF
--- a/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
+++ b/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
@@ -165,7 +165,7 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
             preset=input_.preset,
             image=ContainerImage(
                 repository="ghcr.io/apolo-actions/mlflow",
-                tag="v3.1.4",
+                tag="v3.15.1",
             ),
             container=Container(
                 command=mlflow_cmd,


### PR DESCRIPTION
Blocked until `apolo-actions/mlflow#83` is merged and released — the `v3.15.1` tag does not exist in the registry yet, so this is a draft. Everything else is ready.

## Why

The app pinned the MLflow **server** at `v3.1.4`, while the platform base image ships the MLflow **client** at `3.14.0` (apolo-base-image#657). That is 13 minors of skew in the dangerous direction: the client can call tracking and artifact APIs the server does not implement.

Follow-up from IT-118, flagged by @ysvydiuk during review of apolo-base-image#657.

## What

One line — the server tag. apolo-actions/mlflow#83 does the actual work of rebuilding the image on MLflow 3.15.1 (which also required moving that image off Python 3.9, since `mlflow>=3.10` needs Python `>=3.10`).

`3.15.1` rather than exact parity at `3.14.0`: server-newer-than-client is the supported direction, and Dependabot has been dead in the image repo since 2025-02, so whatever is pinned there tends to stay for a long time. The base image can align on 3.15.x in its next routine dependency refresh.

## Checks

`pytest .apolo/tests/unit` — 29 passed. `mypy .apolo` — clean. `pre-commit run --all-files` — all hooks pass, including `Generate types schemas`, which reports no drift: the server tag is not part of the generated schemas, so no regeneration is involved.

Upgrade safety was verified in apolo-actions/mlflow#83 rather than here — MLflow migrates its backend schema on startup and does not support downgrades, so a database seeded by the deployed `v3.1.4` image was upgraded in place under `3.15.1` on both sqlite and PostgreSQL. The alembic revision moves `bda7b8c39065` → `6f8d9c3b2a1e`, and legacy experiments, runs, params, metrics, tags, proxied artifacts and registered models all survive, with new writes still accepted. That matters here because both backends this app can configure are covered: the sqlite PVC path and `get_postgres_database_url`.

**Existing installations take a one-way step.** Any MLflow app instance that is upgraded migrates its backend schema and cannot be rolled back to `v3.1.4` afterwards.

## Notes

- `apolo-app-types` is already at `26.8.1` on master via #361, so the lock resolves `kubernetes 35.0.0`. That matters for this app specifically — it is `install_type: workflow`, and the IT-130 bug (`kubernetes` 36.x breaking in-cluster SA auth, which silently empties app outputs and drops "Open App") would otherwise ship with the hook image this change triggers. Nothing to do here, noting it so the interaction is on record.
- `.apolo/applications.yaml` points every app at `./CHANGELOG.md`, but that file has never existed in this repo. Not creating one here — it applies to all apps, not just MLflow, so it deserves its own change.
- After this merges, the in-cluster verification on dev still needs doing: probes, ingress, artifact store on an Apolo Files mount, and the outputs postprocessor. None of that is exercised by unit tests.