### PR TITLE
IT-143: allow the app's own hosts and switch off MLflow server jobs

### DIFF
--- a/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
+++ b/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
@@ -32,16 +32,10 @@ from apolo_app_types.protocols.custom_deployment import (
 from apolo_apps_mlflow_core.types import MLFlowAppInputs, MLFlowMetadataPostgres
 
 
-# MLflow 3.x rejects any request whose Host header it does not recognise, with
-# 403 "Invalid Host header - possible DNS rebinding attack detected". Its
-# built-in list covers loopback and private IPs, so the kubelet probes pass
-# (they address the pod IP) while the ingress hostname and the in-cluster
-# service name are both refused — the app reports healthy while every request a
-# user actually makes fails.
-#
-# MLFLOW_SERVER_ALLOWED_HOSTS *replaces* that built-in list rather than adding
-# to it, so the defaults are repeated here; dropping them would break the
-# probes. Mirrors mlflow.server.security_utils.get_default_allowed_hosts().
+# MLFLOW_SERVER_ALLOWED_HOSTS replaces MLflow's own defaults instead of adding
+# to it, and they include the private IPs the kubelet probes come from — so
+# dropping them here would fail the probes. Mirrors
+# mlflow.server.security_utils.get_default_allowed_hosts().
 _MLFLOW_DEFAULT_ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
@@ -121,12 +115,9 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
     def _gen_allowed_hosts(base_vals: dict[str, t.Any], namespace: str) -> list[str]:
         """Host headers MLflow should answer, on top of its own defaults.
 
-        Covers the ingress hostname the UI is served on and the in-cluster
-        service name. The latter is reached under several suffixes: platform
-        jobs address it as `<svc>.<namespace>`, while the outputs sidecar uses
-        the fully qualified `<svc>.<namespace>.svc.cluster.local`. MLflow
-        matches the Host header verbatim and does not strip the port, so every
-        form needs both a bare and a `:port` pattern.
+        The in-cluster service is addressed under several DNS suffixes: jobs use
+        `<svc>.<namespace>`, the outputs sidecar the fully qualified form.
+        Matching is literal and keeps the port, hence the `:*` variants.
         """
         allowed = [*_MLFLOW_DEFAULT_ALLOWED_HOSTS]
         for suffix in ("", ".svc", ".svc.cluster.local"):
@@ -187,11 +178,8 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
             )
         )
 
-        # The Huey-backed job scheduler behind MLflow's server-side GenAI
-        # features (online scoring, trace archival, judges) idles at well over a
-        # gigabyte — see mlflow/mlflow#22792 and #23702. None of it is used by a
-        # tracking server and model registry, and leaving it on pushes the
-        # container past the memory limit of the smaller presets.
+        # Unused here, and its Huey workers idle at over a gigabyte, which
+        # overruns the smaller presets (mlflow/mlflow#22792, #23702).
         envs.append(Env(name="MLFLOW_SERVER_ENABLE_JOB_EXECUTION", value="false"))
 
         artifact_mounts: StorageMounts | None = None

--- a/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
+++ b/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
@@ -121,15 +121,16 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
     def _gen_allowed_hosts(base_vals: dict[str, t.Any], namespace: str) -> list[str]:
         """Host headers MLflow should answer, on top of its own defaults.
 
-        Adds the in-cluster service name, which clients running as platform jobs
-        use, and the ingress hostname the UI is served on. MLflow compares the
-        Host header verbatim, so entries carrying a port need their own pattern.
+        Covers the ingress hostname the UI is served on and the in-cluster
+        service name. The latter is reached under several suffixes: platform
+        jobs address it as `<svc>.<namespace>`, while the outputs sidecar uses
+        the fully qualified `<svc>.<namespace>.svc.cluster.local`. MLflow
+        matches the Host header verbatim and does not strip the port, so every
+        form needs both a bare and a `:port` pattern.
         """
-        allowed = [
-            *_MLFLOW_DEFAULT_ALLOWED_HOSTS,
-            f"*.{namespace}",
-            f"*.{namespace}:*",
-        ]
+        allowed = [*_MLFLOW_DEFAULT_ALLOWED_HOSTS]
+        for suffix in ("", ".svc", ".svc.cluster.local"):
+            allowed += [f"*.{namespace}{suffix}", f"*.{namespace}{suffix}:*"]
         for host_cfg in base_vals.get("ingress", {}).get("hosts", []):
             if host := host_cfg.get("host"):
                 allowed += [host, f"{host}:*"]

--- a/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
+++ b/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
@@ -32,6 +32,33 @@ from apolo_app_types.protocols.custom_deployment import (
 from apolo_apps_mlflow_core.types import MLFlowAppInputs, MLFlowMetadataPostgres
 
 
+# MLflow 3.x rejects any request whose Host header it does not recognise, with
+# 403 "Invalid Host header - possible DNS rebinding attack detected". Its
+# built-in list covers loopback and private IPs, so the kubelet probes pass
+# (they address the pod IP) while the ingress hostname and the in-cluster
+# service name are both refused — the app reports healthy while every request a
+# user actually makes fails.
+#
+# MLFLOW_SERVER_ALLOWED_HOSTS *replaces* that built-in list rather than adding
+# to it, so the defaults are repeated here; dropping them would break the
+# probes. Mirrors mlflow.server.security_utils.get_default_allowed_hosts().
+_MLFLOW_DEFAULT_ALLOWED_HOSTS = [
+    "localhost",
+    "127.0.0.1",
+    "[::1]",
+    "0.0.0.0",
+    "localhost:*",
+    "127.0.0.1:*",
+    "[[]::1]:*",
+    "0.0.0.0:*",
+    "192.168.*",
+    "10.*",
+    *[f"172.{octet}.*" for octet in range(16, 32)],
+    "fc00:*",
+    "fd00:*",
+]
+
+
 class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
     """
     Enhanced MLFlow chart processor that supports:
@@ -90,6 +117,24 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
     async def gen_extra_helm_args(self, *_: t.Any) -> list[str]:
         return ["--timeout", "30m"]
 
+    @staticmethod
+    def _gen_allowed_hosts(base_vals: dict[str, t.Any], namespace: str) -> list[str]:
+        """Host headers MLflow should answer, on top of its own defaults.
+
+        Adds the in-cluster service name, which clients running as platform jobs
+        use, and the ingress hostname the UI is served on. MLflow compares the
+        Host header verbatim, so entries carrying a port need their own pattern.
+        """
+        allowed = [
+            *_MLFLOW_DEFAULT_ALLOWED_HOSTS,
+            f"*.{namespace}",
+            f"*.{namespace}:*",
+        ]
+        for host_cfg in base_vals.get("ingress", {}).get("hosts", []):
+            if host := host_cfg.get("host"):
+                allowed += [host, f"{host}:*"]
+        return allowed
+
     async def gen_extra_values(
         self,
         input_: MLFlowAppInputs,
@@ -133,6 +178,20 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
             backend_uri = "sqlite:///mlflow-data/mlflow.db"
 
         envs.append(Env(name="MLFLOW_TRACKING_URI", value=backend_uri))
+
+        envs.append(
+            Env(
+                name="MLFLOW_SERVER_ALLOWED_HOSTS",
+                value=",".join(self._gen_allowed_hosts(base_vals, namespace)),
+            )
+        )
+
+        # The Huey-backed job scheduler behind MLflow's server-side GenAI
+        # features (online scoring, trace archival, judges) idles at well over a
+        # gigabyte — see mlflow/mlflow#22792 and #23702. None of it is used by a
+        # tracking server and model registry, and leaving it on pushes the
+        # container past the memory limit of the smaller presets.
+        envs.append(Env(name="MLFLOW_SERVER_ENABLE_JOB_EXECUTION", value="false"))
 
         artifact_mounts: StorageMounts | None = None
         artifact_env_val = None

--- a/.apolo/tests/unit/mlflow/test_input_generation.py
+++ b/.apolo/tests/unit/mlflow/test_input_generation.py
@@ -198,3 +198,63 @@ async def test_values_mlflow_generation_postgres_uri(
     assert artifact_env["value"] == "file:///mlflow-artifacts"
 
     assert helm_params["labels"]["application"] == "mlflow"
+
+
+@pytest.mark.asyncio
+async def test_values_mlflow_allowed_hosts_and_jobs_disabled(
+    setup_clients, mock_get_preset_cpu
+):
+    """
+    MLflow 3.x answers 403 for any Host header it does not recognise, and its
+    defaults cover only loopback and private IPs — which the kubelet probes
+    satisfy while real traffic does not. Setting MLFLOW_SERVER_ALLOWED_HOSTS
+    replaces those defaults rather than extending them, so the generated list
+    has to carry the ingress hostname, the in-cluster service name and the
+    original defaults all at once.
+    """
+    input_data = MLFlowAppInputs(
+        preset=Preset(name="cpu-small"),
+        ingress_http=IngressHttp(clusterName="test"),
+        metadata_storage=MLFlowMetadataSQLite(),
+        artifact_store=ApoloFilesPath(
+            path="storage://test-cluster/myorg/proj/mlflow-artifacts"
+        ),
+    )
+    processor = MLFlowChartValueProcessor(client=setup_clients)
+    helm_params = await processor.gen_extra_values(
+        input_=input_data,
+        app_name="my-mlflow",
+        namespace=DEFAULT_NAMESPACE,
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    env_vars = helm_params["container"]["env"]
+    allowed_env = next(
+        (e for e in env_vars if e["name"] == "MLFLOW_SERVER_ALLOWED_HOSTS"), None
+    )
+    assert allowed_env is not None
+    allowed = allowed_env["value"].split(",")
+
+    # probes address the pod IP, so the private-IP defaults must survive
+    assert "10.*" in allowed
+    assert "localhost" in allowed
+
+    # clients running as platform jobs reach the service by its in-cluster name,
+    # and send a port in the Host header
+    assert f"*.{DEFAULT_NAMESPACE}" in allowed
+    assert f"*.{DEFAULT_NAMESPACE}:*" in allowed
+
+    # the UI is served on the ingress hostname
+    ingress_hosts = [h["host"] for h in helm_params["ingress"]["hosts"]]
+    assert ingress_hosts
+    for host in ingress_hosts:
+        assert host in allowed
+        assert f"{host}:*" in allowed
+
+    jobs_env = next(
+        (e for e in env_vars if e["name"] == "MLFLOW_SERVER_ENABLE_JOB_EXECUTION"),
+        None,
+    )
+    assert jobs_env is not None
+    assert jobs_env["value"] == "false"

--- a/.apolo/tests/unit/mlflow/test_input_generation.py
+++ b/.apolo/tests/unit/mlflow/test_input_generation.py
@@ -1,3 +1,5 @@
+import fnmatch
+
 import pytest
 from apolo_app_types_fixtures.constants import (
     APP_ID,
@@ -240,10 +242,22 @@ async def test_values_mlflow_allowed_hosts_and_jobs_disabled(
     assert "10.*" in allowed
     assert "localhost" in allowed
 
-    # clients running as platform jobs reach the service by its in-cluster name,
-    # and send a port in the Host header
-    assert f"*.{DEFAULT_NAMESPACE}" in allowed
-    assert f"*.{DEFAULT_NAMESPACE}:*" in allowed
+    # the in-cluster service is addressed under several DNS suffixes: platform
+    # jobs use the short form, the outputs sidecar the fully qualified one. The
+    # port is part of the Host header and is not stripped before matching.
+    internal_hosts = [
+        f"mlflow-svc.{DEFAULT_NAMESPACE}",
+        f"mlflow-svc.{DEFAULT_NAMESPACE}:5000",
+        f"mlflow-svc.{DEFAULT_NAMESPACE}.svc:5000",
+        f"mlflow-svc.{DEFAULT_NAMESPACE}.svc.cluster.local:5000",
+    ]
+    for internal_host in internal_hosts:
+        assert any(
+            fnmatch.fnmatch(internal_host, pattern)
+            if "*" in pattern
+            else internal_host == pattern
+            for pattern in allowed
+        ), f"{internal_host} would be rejected with 403"
 
     # the UI is served on the ingress hostname
     ingress_hosts = [h["host"] for h in helm_params["ingress"]["hosts"]]

--- a/.apolo/tests/unit/mlflow/test_input_generation.py
+++ b/.apolo/tests/unit/mlflow/test_input_generation.py
@@ -206,14 +206,7 @@ async def test_values_mlflow_generation_postgres_uri(
 async def test_values_mlflow_allowed_hosts_and_jobs_disabled(
     setup_clients, mock_get_preset_cpu
 ):
-    """
-    MLflow 3.x answers 403 for any Host header it does not recognise, and its
-    defaults cover only loopback and private IPs — which the kubelet probes
-    satisfy while real traffic does not. Setting MLFLOW_SERVER_ALLOWED_HOSTS
-    replaces those defaults rather than extending them, so the generated list
-    has to carry the ingress hostname, the in-cluster service name and the
-    original defaults all at once.
-    """
+    """Every Host that reaches MLflow must be allowed, or it answers 403."""
     input_data = MLFlowAppInputs(
         preset=Preset(name="cpu-small"),
         ingress_http=IngressHttp(clusterName="test"),
@@ -242,9 +235,6 @@ async def test_values_mlflow_allowed_hosts_and_jobs_disabled(
     assert "10.*" in allowed
     assert "localhost" in allowed
 
-    # the in-cluster service is addressed under several DNS suffixes: platform
-    # jobs use the short form, the outputs sidecar the fully qualified one. The
-    # port is part of the Host header and is not stripped before matching.
     internal_hosts = [
         f"mlflow-svc.{DEFAULT_NAMESPACE}",
         f"mlflow-svc.{DEFAULT_NAMESPACE}:5000",
@@ -259,7 +249,6 @@ async def test_values_mlflow_allowed_hosts_and_jobs_disabled(
             for pattern in allowed
         ), f"{internal_host} would be rejected with 403"
 
-    # the UI is served on the ingress hostname
     ingress_hosts = [h["host"] for h in helm_params["ingress"]["hosts"]]
     assert ingress_hosts
     for host in ingress_hosts:


### PR DESCRIPTION
Fixes the two regressions IT-122 exposed. Both were found on dev and neither reproduces locally, so they slipped past the image bump.

## 1. Host allowlist — the app was fully unusable

MLflow 3.x refuses any Host header outside its allowlist with `403 Invalid Host header - possible DNS rebinding attack detected`. Measured against a live pod on dev, on the tag this app now pins:

| Host | before |
|---|---|
| `localhost:5000`, `127.0.0.1:5000` | 200 |
| `<svc>.<project-ns>:5000` (what platform jobs use) | **403** |
| `mlflow--<id>.apps.dev.apolo.us` (the UI) | **403** |

So the UI and the tracking API were both dead. `v3.1.4` returns 200 for the same test — this arrived with the version.

The reason it went unnoticed is the shape of MLflow's default list: it is not "localhost only" but **loopback plus private IP ranges**. The kubelet probes address the pod IP, so they pass, and `/health` is exempt from the middleware entirely — **the app reports `healthy` while every request a user makes fails.**

`MLFLOW_SERVER_ALLOWED_HOSTS` **replaces** that default list rather than extending it (`get_allowed_hosts_from_env() or get_default_allowed_hosts()`), so the defaults are mirrored in `_MLFLOW_DEFAULT_ALLOWED_HOSTS` and carried over. Dropping them would break the probes and CrashLoop the app — that is the trap this constant exists to avoid, hence the comment on it.

Matching is `fnmatch` for patterns and exact equality otherwise, against the Host header verbatim — **the port is not stripped**. A wildcard like `*.<ns>` therefore matches `svc.<ns>` but not `svc.<ns>:5000`, which is why each host is added both bare and with a `:*` variant.

## 2. Memory — jobs off, not a bigger preset

The container was OOMKilled into CrashLoopBackOff on `cpu-medium` (limit 1907M). This is a known upstream problem — [mlflow#23702](https://github.com/mlflow/mlflow/issues/23702) reports 2.4 GB idle per replica on 3.12.0 in Kubernetes, [mlflow#22792](https://github.com/mlflow/mlflow/issues/22792) ties the growth to the Huey-backed GenAI job scheduler. Both open.

`MLFLOW_SERVER_ENABLE_JOB_EXECUTION=false` turns that scheduler off. Measured in-cluster with the limit pinned to 1907M, exactly `cpu-medium`:

| config | memory | huey procs | restarts |
|---|---|---|---|
| jobs enabled | 2141 Mi | 7 | OOMKilled |
| jobs disabled | **863 Mi** | 0 | **0** |

`v3.1.4` idles at 553 Mi for comparison. What is given up is server-side online scoring, trace archival and judges — none of which a tracking server and model registry use. Verified in that state: runs, params, metrics, artifact upload through `--serve-artifacts`, and model registration all work.

Doing it this way rather than raising the preset matters for **existing installations** — the preset comes from user configuration, so a floor increase would strand anyone already on a small one.

## Checks

`pytest .apolo/tests/unit` — 30 passed, including two new assertions covering the generated host list and the jobs flag. `mypy .apolo` clean. `pre-commit run --all-files` green, `Generate types schemas` reports no drift.

In-cluster verification on dev follows once CI publishes the branch hook image; I will post the result here.

## Note

`kubectl set env` on the app's deployment does not stick — the platform reconciles it away and the replacement pod comes back without the variable. The numbers above came from a standalone pod cloned from the live spec, not a patched deployment.