### PR TITLE
IT-143: allow the UI's own origin through MLflow's CORS check

### DIFF
--- a/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
+++ b/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
@@ -122,10 +122,31 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
         allowed = [*_MLFLOW_DEFAULT_ALLOWED_HOSTS]
         for suffix in ("", ".svc", ".svc.cluster.local"):
             allowed += [f"*.{namespace}{suffix}", f"*.{namespace}{suffix}:*"]
-        for host_cfg in base_vals.get("ingress", {}).get("hosts", []):
-            if host := host_cfg.get("host"):
-                allowed += [host, f"{host}:*"]
+        for host in MLFlowChartValueProcessor._ingress_hosts(base_vals):
+            allowed += [host, f"{host}:*"]
         return allowed
+
+    @staticmethod
+    def _ingress_hosts(base_vals: dict[str, t.Any]) -> list[str]:
+        return [
+            host
+            for host_cfg in base_vals.get("ingress", {}).get("hosts", [])
+            if (host := host_cfg.get("host"))
+        ]
+
+    @staticmethod
+    def _gen_allowed_origins(base_vals: dict[str, t.Any]) -> list[str]:
+        """Origins allowed to send state-changing requests.
+
+        MLflow blocks every non-localhost origin on POST/PUT/DELETE unless it is
+        listed, and the browser sends an Origin even same-origin — so without
+        this the UI loads over the ingress but every write, including
+        `runs/search`, comes back 403.
+        """
+        origins = []
+        for host in MLFlowChartValueProcessor._ingress_hosts(base_vals):
+            origins += [f"https://{host}", f"http://{host}"]
+        return origins
 
     async def gen_extra_values(
         self,
@@ -177,6 +198,13 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
                 value=",".join(self._gen_allowed_hosts(base_vals, namespace)),
             )
         )
+        if allowed_origins := self._gen_allowed_origins(base_vals):
+            envs.append(
+                Env(
+                    name="MLFLOW_SERVER_CORS_ALLOWED_ORIGINS",
+                    value=",".join(allowed_origins),
+                )
+            )
 
         # Unused here, and its Huey workers idle at over a gigabyte, which
         # overruns the smaller presets (mlflow/mlflow#22792, #23702).

--- a/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
+++ b/.apolo/src/apolo_apps_mlflow_core/inputs_processor.py
@@ -53,6 +53,14 @@ _MLFLOW_DEFAULT_ALLOWED_HOSTS = [
 ]
 
 
+def _ingress_hosts(base_vals: dict[str, t.Any]) -> list[str]:
+    return [
+        host
+        for host_cfg in base_vals.get("ingress", {}).get("hosts", [])
+        if (host := host_cfg.get("host"))
+    ]
+
+
 class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
     """
     Enhanced MLFlow chart processor that supports:
@@ -122,17 +130,9 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
         allowed = [*_MLFLOW_DEFAULT_ALLOWED_HOSTS]
         for suffix in ("", ".svc", ".svc.cluster.local"):
             allowed += [f"*.{namespace}{suffix}", f"*.{namespace}{suffix}:*"]
-        for host in MLFlowChartValueProcessor._ingress_hosts(base_vals):
+        for host in _ingress_hosts(base_vals):
             allowed += [host, f"{host}:*"]
         return allowed
-
-    @staticmethod
-    def _ingress_hosts(base_vals: dict[str, t.Any]) -> list[str]:
-        return [
-            host
-            for host_cfg in base_vals.get("ingress", {}).get("hosts", [])
-            if (host := host_cfg.get("host"))
-        ]
 
     @staticmethod
     def _gen_allowed_origins(base_vals: dict[str, t.Any]) -> list[str]:
@@ -141,10 +141,11 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
         MLflow blocks every non-localhost origin on POST/PUT/DELETE unless it is
         listed, and the browser sends an Origin even same-origin — so without
         this the UI loads over the ingress but every write, including
-        `runs/search`, comes back 403.
+        `runs/search`, comes back 403. Both schemes are served: reaching the app
+        over http does not redirect, it authenticates and returns there.
         """
         origins = []
-        for host in MLFlowChartValueProcessor._ingress_hosts(base_vals):
+        for host in _ingress_hosts(base_vals):
             origins += [f"https://{host}", f"http://{host}"]
         return origins
 

--- a/.apolo/tests/unit/mlflow/test_input_generation.py
+++ b/.apolo/tests/unit/mlflow/test_input_generation.py
@@ -261,3 +261,37 @@ async def test_values_mlflow_allowed_hosts_and_jobs_disabled(
     )
     assert jobs_env is not None
     assert jobs_env["value"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_values_mlflow_cors_allows_the_ui_origin(
+    setup_clients, mock_get_preset_cpu
+):
+    """The UI's own origin must be allowed, or every write from it 403s."""
+    input_data = MLFlowAppInputs(
+        preset=Preset(name="cpu-small"),
+        ingress_http=IngressHttp(clusterName="test"),
+        metadata_storage=MLFlowMetadataSQLite(),
+    )
+    processor = MLFlowChartValueProcessor(client=setup_clients)
+    helm_params = await processor.gen_extra_values(
+        input_=input_data,
+        app_name="my-mlflow",
+        namespace=DEFAULT_NAMESPACE,
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    origins = next(
+        e
+        for e in helm_params["container"]["env"]
+        if e["name"] == "MLFLOW_SERVER_CORS_ALLOWED_ORIGINS"
+    )["value"].split(",")
+
+    ingress_hosts = [h["host"] for h in helm_params["ingress"]["hosts"]]
+    assert ingress_hosts
+    for host in ingress_hosts:
+        assert f"https://{host}" in origins
+
+    # only our own origins, so a foreign site still cannot post here
+    assert all(any(host in o for host in ingress_hosts) for o in origins)


### PR DESCRIPTION
Follow-up to #363, which fixed the Host allowlist but left a second gate closed. Found by clicking the UI in a browser on dev — the check I flagged there as untested, and it turned out to matter.

## What happens

The page loads and the experiment list renders, so it looks fine. But every state-changing request fails:

```
POST /ajax-api/2.0/mlflow/runs/search    -> 403
POST /ajax-api/3.0/mlflow/traces/metrics -> 403  (x11)
```

Response body: `Cross-origin request blocked`.

From `mlflow.server.security_utils`:

```python
def should_block_cors_request(origin, method, allowed_origins):
    if not origin or method not in STATE_CHANGING_METHODS: return False  # GET is exempt
    if is_localhost_origin(origin): return False
    if allowed_origins: ...match...
    return True                                                          # default: block
```

and `get_allowed_origins()` returns `get_allowed_origins_from_env() or []` — **empty unless configured**. Browsers attach an `Origin` header to same-origin POSTs too, so the UI blocks itself against its own backend.

## Why the previous round missed it

Everything checked in #363 was either a GET or a non-browser client. `curl` sends no `Origin`, so it sails through; the python client likewise. And the page render is all GETs, so a screenshot looks correct. Only a browser doing a POST reproduces it, which is exactly why this was called out as unverified there.

## Verified

Against the built image, with the Host allowlist already in place:

| request | without the fix | with it |
|---|---|---|
| POST, our own origin | 403 | **200** |
| POST, `https://evil.example.com` | 403 | **403** |
| POST, no Origin (CLI / python client) | 200 | 200 |

So this opens the UI's own origin and nothing else; a foreign site still cannot post here, and non-browser clients are unaffected either way.

Unlike `MLFLOW_SERVER_ALLOWED_HOSTS`, the origin list needs no re-statement of defaults — localhost is handled by `is_localhost_origin` before the allowlist is consulted, so only the ingress origins are added. Both schemes are emitted for the same hostname, so an `http` origin behind the TLS-terminating ingress cannot reintroduce the failure.

`pytest .apolo/tests/unit` — 31 passed, including a new case asserting the UI origin is present and that nothing beyond our own hosts is. `mypy` clean, `pre-commit` green.

Browser re-check on dev to follow once this is installable there.